### PR TITLE
Add region argument and sanity filters

### DIFF
--- a/ssh2ec2/__init__.py
+++ b/ssh2ec2/__init__.py
@@ -8,7 +8,7 @@ import os
 
 def get_filters(args):
     """ Return a dict of filters based on the given arguments """
-    filters = {}
+    filters = {'instance_state_name': 'running'}
 
     if args.tag:
         for t in args.tag:

--- a/ssh2ec2/__init__.py
+++ b/ssh2ec2/__init__.py
@@ -99,21 +99,21 @@ def main():
     else:
         print "Found %s instance(s)" % len(instances)
 
-    instance_dns_names = []
+    instance_addresses = []
     if args.all_matching_instances:
         for instance in instances:
             if instance.public_dns_name != '':
-                instance_dns_names.append(instance.public_dns_name)
+                instance_addresses.append(instance.public_dns_name)
     else:
         # Pick a random instance from the results, that is directly reachable
-        while ((len(instance_dns_names) < 1) and (len(instances) > 0)):
+        while ((len(instance_addresses) < 1) and (len(instances) > 0)):
             instance = instances.pop(random.randint(0, len(instances)) - 1)
             if instance.public_dns_name != '':
-                instance_dns_names.append(instance.public_dns_name)
+                instance_addresses.append(instance.public_dns_name)
             elif instance.ip_address != '':
-                instance_dns_names.append(instance.ip_address)
+                instance_addresses.append(instance.ip_address)
 
-    if len(instance_dns_names) < 1:
+    if len(instance_addresses) < 1:
         print "No instances had public ips. Exiting..."
         sys.exit(1)
 
@@ -122,11 +122,11 @@ def main():
     else:
         remote_command = ''
 
-    for dns_name in instance_dns_names:
+    for address in instance_addresses:
         if args.ssh_user:
-            dns_name = '%s@%s' % (args.ssh_user, dns_name)
+            address = '%s@%s' % (args.ssh_user, address)
 
-        ssh_cmd = 'ssh %s %s %s' % (args.ssh_args, dns_name, remote_command)
+        ssh_cmd = 'ssh %s %s %s' % (args.ssh_args, address, remote_command)
         os.system(ssh_cmd)
 
 

--- a/ssh2ec2/__init__.py
+++ b/ssh2ec2/__init__.py
@@ -110,6 +110,8 @@ def main():
             instance = instances.pop(random.randint(0, len(instances)) - 1)
             if instance.public_dns_name != '':
                 instance_dns_names.append(instance.public_dns_name)
+            elif instance.ip_address != '':
+                instance_dns_names.append(instance.ip_address)
 
     if len(instance_dns_names) < 1:
         print "No instances had public ips. Exiting..."

--- a/ssh2ec2/__init__.py
+++ b/ssh2ec2/__init__.py
@@ -1,4 +1,5 @@
 import argparse
+import boto.ec2
 import boto
 import sys
 import random
@@ -70,6 +71,7 @@ def parse_args():
     # AWS connection args
     parser.add_argument('--credentials-profile',
                         help='The name of a profile configured in the AWS credentials file')
+    parser.add_argument('--region', default='us-east-1')
     # SSH args
     parser.add_argument('--ssh-user', help='Username to use for SSH connection')
     parser.add_argument('--ssh-args', default='', help='Additional arguments for SSH')
@@ -85,7 +87,7 @@ def main():
     args = parse_args()
     # Retrieve a list of instances that match the filters
     try:
-        conn = boto.connect_ec2(profile_name=args.credentials_profile)
+        conn = boto.ec2.connect_to_region(args.region, profile_name=args.credentials_profile)
     except boto.provider.ProfileNotFoundError:
         print 'Credentials profile "%s" not found' % args.credentials_profile
         sys.exit(1)

--- a/ssh2ec2/__init__.py
+++ b/ssh2ec2/__init__.py
@@ -96,6 +96,8 @@ def main():
     if len(instances) == 0:
         print 'No instances matching criteria'
         sys.exit(1)
+    else:
+        print "Found %s instance(s)" % len(instances)
 
     instance_dns_names = []
     if args.all_matching_instances:

--- a/ssh2ec2/__init__.py
+++ b/ssh2ec2/__init__.py
@@ -100,11 +100,18 @@ def main():
     instance_dns_names = []
     if args.all_matching_instances:
         for instance in instances:
-            instance_dns_names.append(instance.public_dns_name)
+            if instance.public_dns_name != '':
+                instance_dns_names.append(instance.public_dns_name)
     else:
-        # Pick a random instance from the results
-        instance = instances[random.randrange(0, len(instances))]
-        instance_dns_names.append(instance.public_dns_name)
+        # Pick a random instance from the results, that is directly reachable
+        while ((len(instance_dns_names) < 1) and (len(instances) > 0)):
+            instance = instances.pop(random.randint(0, len(instances)) - 1)
+            if instance.public_dns_name != '':
+                instance_dns_names.append(instance.public_dns_name)
+
+    if len(instance_dns_names) < 1:
+        print "No instances had public ips. Exiting..."
+        sys.exit(1)
 
     if args.command:
         remote_command = ' '.join(args.command)


### PR DESCRIPTION
Hi, I've added a region argument for those who work with multiple regions simultaneously. I've also added filters to only try to connect to running instances with public IPs, and logic to connect to IPs if DNS is not assigned.