### PR TITLE
Fall back to private ip address for instances with no public dns name.

### DIFF
--- a/ssh2ec2/__init__.py
+++ b/ssh2ec2/__init__.py
@@ -1,9 +1,10 @@
 import argparse
+import os
+import random
+import sys
+
 import boto3
 from botocore.exceptions import ProfileNotFound
-import sys
-import random
-import os
 
 
 def get_filters(args):
@@ -140,7 +141,8 @@ def main():
         sys.exit(1)
 
     instance_dns_names = [[
-        instance['PublicDnsName'] for instance in reservation['Instances']][0]
+        instance['PublicDnsName'] or instance['PrivateIpAddress']
+        for instance in reservation['Instances']][0]
         for reservation
         in reservations['Reservations']]
     if args.all_matching_instances:


### PR DESCRIPTION
Currently trying to login to machines spawned without public interface (eg: inside a private VPC with VPN connection) will result in an error because an empty string is passed as 'host' argument to ssh. This change will use an instance's private ip address if it has no public hostname.