### PR TITLE
Get all instances in each reservation, not just the first

### DIFF
--- a/ssh2ec2/__init__.py
+++ b/ssh2ec2/__init__.py
@@ -139,10 +139,12 @@ def main():
         print('No instances matching criteria')
         sys.exit(1)
 
-    instance_dns_names = [[
-        instance['PublicDnsName'] for instance in reservation['Instances']][0]
-        for reservation
-        in reservations['Reservations']]
+    instance_dns_names = [
+            instance['PublicDnsName']
+            for reservation
+            in reservations['Reservations']
+            for instance
+            in reservation['Instances']]
     if args.all_matching_instances:
         pass
     else:


### PR DESCRIPTION
The previous list comprehension was slicing off only the first instance in each reservation. Now all instances in each reservation are included. If you had an autoscale group and had the `MaxBatchSize` greater than one, `ssh2ec2` would only find the first instance in the reservation. 

@mikery 